### PR TITLE
Fixes issue #8

### DIFF
--- a/src/parsing/SplGeneratorModels/SequenceDiagramTransformer.java
+++ b/src/parsing/SplGeneratorModels/SequenceDiagramTransformer.java
@@ -24,7 +24,12 @@ public class SequenceDiagramTransformer {
 		root = null;
 	}
 
-	public RDGNode transformSD(SequenceDiagram s, String id) {
+	public RDGNode transformSD(SequenceDiagram s) {
+	    String id = s.getName();
+	    RDGNode reusableNode = RDGNode.getById(id);
+	    if (reusableNode != null) {
+	        return reusableNode;
+	    }
 		FDTMC f = new FDTMC();
 		f.setVariableName(s.getName() + "_s");
 		RDGNode answer = new RDGNode(id, s.getGuardCondition(), f);
@@ -79,7 +84,7 @@ public class SequenceDiagramTransformer {
 				SequenceDiagram onlySD = fr.getSequenceDiagrams()
 						.getFirst();
 				SequenceDiagramTransformer transformer = new SequenceDiagramTransformer();
-				RDGNode dependencyNode = transformer.transformSD(onlySD, RDGNode.getNextId());
+				RDGNode dependencyNode = transformer.transformSD(onlySD);
 				this.root.addDependency(dependencyNode);
 
 				String dependencyName = dependencyNode.getId();

--- a/src/parsing/SplGeneratorModels/Transformer.java
+++ b/src/parsing/SplGeneratorModels/Transformer.java
@@ -99,7 +99,7 @@ public class Transformer {
 				// TODO Throw exception if there is more than one associated SD
 				SequenceDiagram onlyAssociatedSD = a.getSequenceDiagrams().getFirst();
 				SequenceDiagramTransformer sdt = new SequenceDiagramTransformer();
-				RDGNode dependencyNode = sdt.transformSD(onlyAssociatedSD, onlyAssociatedSD.getName());
+				RDGNode dependencyNode = sdt.transformSD(onlyAssociatedSD);
 				this.root.addDependency(dependencyNode);
 
 				// An activity should have only one transition (to another activity or to a decision node).


### PR DESCRIPTION
The root cause of that bug was that the transformation code wasn't even
attempting to reuse RDG nodes already created for the fragment
references in the model.

Hence, I changed the method `SequenceDiagramTransformer.transformSD()`
to take only a SequenceDiagram as input and to infer the RDG node ID
from it. This way, the behavior became consistent between AD and SD
transformations.
Building on such consistency, I took the node ID to be the fragment name
(used to identify fragments and fragment references in AndreML) and
checked for previously created RDG nodes with the same ID (the class
`RDGNode` already kept track of that information).